### PR TITLE
Adding a helper for strata indexing

### DIFF
--- a/lib/aweplug/helpers/faraday.rb
+++ b/lib/aweplug/helpers/faraday.rb
@@ -1,0 +1,22 @@
+require 'logger'
+require 'aweplug/cache/file_cache'
+require 'faraday'
+require 'faraday_middleware'
+
+module Aweplug
+  module Helpers
+    # Helper for faraday actions
+    class FaradayHelper
+      def self.default url, logger = ::Logger.new('_tmp/faraday.log', 'daily'), cache = Aweplug::Cache::FileCache.new
+        conn = Faraday.new(url: url) do |builder|
+          builder.response :logger, @logger = logger
+          builder.use FaradayMiddleware::Caching, cache, {}
+          builder.adapter :net_http
+          builder.options.params_encoder = Faraday::FlatParamsEncoder
+          builder.ssl.verify = true
+        end 
+        conn
+      end
+    end
+  end
+end


### PR DESCRIPTION
This takes some options to search strata (customer portal), then pushes articles and solutions to searchisko.

The strata url, options for the search (sent via query string) and searchisko options (:logger, :url, :cache, :searchisko_warnings) should be sent, but are not required. The strata URL is technically the only required option, though it won't do much without the search_opts filled out.

This also expects ENV['strata_username'], ENV['strata_password'], ENV['dcp_username'] and ENV['dcp_password'] to be available before calling  the method.

Yes, I know it needs some documentation. Just getting this out there for
another set of eyes to look at.
