### PR TITLE
DEVELOPER-1023 'AeroGear Push 101' YouTube video fails to get added

### DIFF
--- a/lib/aweplug/helpers/video/youtube.rb
+++ b/lib/aweplug/helpers/video/youtube.rb
@@ -13,7 +13,7 @@ module Aweplug
         include Aweplug::Helpers::Video::Helpers
         include Aweplug::GoogleAPIs
 
-        YOUTUBE_URL_PATTERN = /^https?:\/\/(www\.)?youtube\.com\/(watch|playlist)\?(list=|v=)(\w*)$/
+        YOUTUBE_URL_PATTERN = /^https?:\/\/(www\.)?youtube\.com\/(watch|playlist)\?(list=|v=)([\w-]*)$/
 
         # This OAuth 2.0 access scope allows for full read/write access to the
         # authenticated user's account.


### PR DESCRIPTION
This covers all current characters used in a YouTube video id. 
