### PR TITLE
Updates to use a cache per call type

### DIFF
--- a/lib/aweplug/cache.rb
+++ b/lib/aweplug/cache.rb
@@ -5,20 +5,16 @@ module Aweplug
   module Cache
     # Public, returns a default cache based on the profile being run.
     #
-    # site - Awestruct Site
+    # site        - Awestruct Site
+    # default_ttl - Time in seconds for the default ttl for the cache
     #
     # Returns the cache for the profile.
-    def self.default site
-      if (site.send('cache').nil? || !site.respond_to?('cache'))
-        if (site.profile =~ /development/)
-          cache = Aweplug::Cache::FileCache.new 
-        else
-          cache = Aweplug::Cache::JDGCache.new(site.profile, ENV['cache_url'], ENV['cache_user'], ENV['cache_password'])
-        end
-
-        site.send('cache=', cache)
+    def self.default site, default_ttl: 360 
+      if (site.profile =~ /development/)
+        cache = Aweplug::Cache::FileCache.new 
+      else
+        cache = Aweplug::Cache::JDGCache.new(site.profile, ENV['cache_url'], ENV['cache_user'], ENV['cache_password'], default_ttl)
       end
-      site.cache
     end
   end
 end

--- a/lib/aweplug/cache/jdg_cache.rb
+++ b/lib/aweplug/cache/jdg_cache.rb
@@ -10,10 +10,12 @@ module Aweplug
     class JDGCache
       # Public: Initialization method.
       #
-      # profile  - profile the site is built with to prepend to keys.
-      # uri      - String or URI containing the JDG URI (required).
-      # username - Username for the JDG instance (required).
-      # password - Password for the JDG instance (required).
+      # profile     - profile the site is built with to prepend to keys.
+      # uri         - String or URI containing the JDG URI (required).
+      # username    - Username for the JDG instance (required).
+      # password    - Password for the JDG instance (required).
+      # default_ttl - Seconds (Integer) for the default ttl for items in 
+      #               the cache, defaults to nil.
       #
       # Examples
       #
@@ -30,11 +32,12 @@ module Aweplug
       #   # => 'data'
       #
       # Returns a new instance of the cache.
-      def initialize(profile, uri, username, password)
+      def initialize(profile, uri, username, password, default_ttl = nil)
         @profile = profile
         @memory_store = {}
         @conn = Aweplug::Helpers::FaradayHelper.default(uri, {:no_cache => true})
         @conn.basic_auth username, password
+        @default_ttl = default_ttl
       end
 
       # Public: Retrieves the data stored previously under the given key.
@@ -72,7 +75,7 @@ module Aweplug
       # Returns the data just saved.
       def write(key, value, opts = {})
         _key = Digest::SHA1.hexdigest key
-        ttl = opts[:ttl] || 86400
+        ttl = opts[:ttl] || @default_ttl
 
         if (value.is_a?(Faraday::Response) && !value.headers['expires'].nil?)
           resp_ttl = DateTime.parse(value.headers['expires']).to_time.to_i - Time.now.to_i

--- a/lib/aweplug/extensions/asciidoc_example.rb
+++ b/lib/aweplug/extensions/asciidoc_example.rb
@@ -82,12 +82,12 @@ module Aweplug
       #
       # Returns nothing.
       def execute site
-        Aweplug::Cache.default site
+        cache = Aweplug::Cache.default site # As these are just PUT/POST requests the cache doesn't really matter
         searchisko = Aweplug::Helpers::Searchisko.new({:base_url => site.dcp_base_url, 
                                                        :authenticate => true, 
                                                        :searchisko_username => ENV['dcp_user'], 
                                                        :searchisko_password => ENV['dcp_password'], 
-                                                       :cache => site.cache,
+                                                       :cache => cache,
                                                        :logger => site.log_faraday,
                                                        :searchisko_warnings => site.searchisko_warnings})
         Find.find @directory do |path|

--- a/lib/aweplug/extensions/kramdown_demo.rb
+++ b/lib/aweplug/extensions/kramdown_demo.rb
@@ -79,7 +79,7 @@ module Aweplug
         # Returns nothing.
         def execute site
           farday = init_faraday(site)
-          Aweplug::Cache.default site
+          @cache = Aweplug::Cache.default site # default cache here shouldn't matter.
 
           ids = []
           if @url.start_with? 'http'
@@ -135,7 +135,7 @@ module Aweplug
                                                           :authenticate => true, 
                                                           :searchisko_username => ENV['dcp_user'], 
                                                           :searchisko_password => ENV['dcp_password'], 
-                                                          :cache => site.cache,
+                                                          :cache => @cache,
                                                           :logger => site.log_faraday,
                                                           :searchisko_warnings => site.searchisko_warnings})
 
@@ -164,7 +164,6 @@ module Aweplug
         end
 
         def init_faraday site
-          Aweplug::Cache.default site
           @faraday ||= Faraday.new do |builder|
             if (site.log_faraday.is_a?(::Logger))
               builder.response :logger, @logger = site.log_faraday
@@ -173,7 +172,7 @@ module Aweplug
             end
             builder.request :url_encoded
             builder.request :retry
-            builder.use FaradayMiddleware::Caching, site.cache, {}
+            builder.use FaradayMiddleware::Caching, @cache, {}
             builder.use FaradayMiddleware::FollowRedirects, limit: 3
             builder.adapter Faraday.default_adapter 
           end

--- a/lib/aweplug/extensions/kramdown_quickstart.rb
+++ b/lib/aweplug/extensions/kramdown_quickstart.rb
@@ -75,14 +75,14 @@ module Aweplug
         #
         # Returns nothing.
         def execute site
-          Aweplug::Cache.default site
+          cache = Aweplug::Cache.default site # default cache shouldn't matter here
 
           Parallel.each(Dir["#{@repo}/*/README.md"], in_threads: 40) do |file|
             searchisko = Aweplug::Helpers::Searchisko.new({:base_url => site.dcp_base_url, 
                                                            :authenticate => true, 
                                                            :searchisko_username => ENV['dcp_user'], 
                                                            :searchisko_password => ENV['dcp_password'], 
-                                                           :cache => site.cache,
+                                                           :cache => cache,
                                                            :logger => site.log_faraday,
                                                            :searchisko_warnings => site.searchisko_warnings})
             next if @excludes.include?(File.dirname(file))

--- a/lib/aweplug/google_apis.rb
+++ b/lib/aweplug/google_apis.rb
@@ -10,7 +10,7 @@ module Aweplug
 
     # Get the Google API Client
     def google_client site, logger: true, authenticate: true, readonly: true
-      Aweplug::Cache.default site
+      cache = Aweplug::Cache.default site
 
       opts = { :application_name => site.application_name, :application_version => site.application_version }
       opts.merge!({:key => ENV['google_api_key']}) if authenticate && readonly
@@ -25,7 +25,7 @@ module Aweplug
             builder.response :logger, @logger = ::Logger.new('_tmp/faraday.log', 'daily')
           end
         end
-        builder.use FaradayMiddleware::Caching, site.cache, {}
+        builder.use FaradayMiddleware::Caching, cache, {}
         builder.adapter :net_http
         builder.response :gzip
         builder.options.params_encoder = Faraday::FlatParamsEncoder

--- a/lib/aweplug/helpers/google_spreadsheets.rb
+++ b/lib/aweplug/helpers/google_spreadsheets.rb
@@ -125,7 +125,7 @@ module Aweplug
           builder.request :retry
           builder.response :raise_error if raise_error
           builder.use FaradayMiddleware::FollowRedirects
-          builder.use FaradayMiddleware::Caching, site.cache, {}
+          builder.use FaradayMiddleware::Caching, Aweplug::Cache.default(site, 360), {}
           #builder.response :json, :content_type => /\bjson$/
           builder.adapter adapter || :net_http
         end

--- a/lib/aweplug/helpers/searchisko.rb
+++ b/lib/aweplug/helpers/searchisko.rb
@@ -32,14 +32,14 @@ module Aweplug
     # Public: A helper class for using Searchisko.
     class Searchisko 
 
-      def self.default site
-        Aweplug::Cache.default site
+      def self.default site, cache_ttl
+        cache = Aweplug::Cache.default site, cache_ttl
 
         Aweplug::Helpers::Searchisko.new({:base_url => site.dcp_base_url, 
                                           :authenticate => true, 
                                           :searchisko_username => ENV['dcp_user'], 
                                           :searchisko_password => ENV['dcp_password'], 
-                                          :cache => site.cache,
+                                          :cache => cache,
                                           :logger => site.log_faraday,
                                           :searchisko_warnings => site.searchisko_warnings})
       end

--- a/lib/aweplug/helpers/video/video_base.rb
+++ b/lib/aweplug/helpers/video/video_base.rb
@@ -5,15 +5,15 @@ module Aweplug
     module Video
       class VideoBase
 
-        def initialize(video, site)
-          Aweplug::Cache.default site
+        def initialize(video, site, default_ttl = 86400) # A day seems good for videos
+          cache = Aweplug::Cache.default site, default_ttl
           @site = site
           @video = video
           @searchisko = Aweplug::Helpers::Searchisko.new({:base_url => @site.dcp_base_url, 
                                                           :authenticate => true, 
                                                           :searchisko_username => ENV['dcp_user'], 
                                                           :searchisko_password => ENV['dcp_password'], 
-                                                          :cache => @site.cache,
+                                                          :cache => cache,
                                                           :logger => @site.log_faraday,
                                                           :searchisko_warnings => @site.searchisko_warnings})
         end

--- a/lib/aweplug/helpers/video/vimeo.rb
+++ b/lib/aweplug/helpers/video/vimeo.rb
@@ -17,10 +17,10 @@ module Aweplug
         VIMEO_URL_PATTERN = /^https?:\/\/vimeo\.com\/(album)?\/?([0-9]+)\/?$/
         BASE_URL = 'https://api.vimeo.com/'
 
-        def initialize site, logger: true, raise_error: false, adapter: nil
+        def initialize site, logger: true, raise_error: false, adapter: nil, default_ttl: 86400 # day default seems good
           @site = site
 
-          Aweplug::Cache.default @site
+          cache = Aweplug::Cache.default @site, default_ttl
 
           @faraday = Faraday.new(:url => BASE_URL) do |builder|
             if (logger) 
@@ -35,7 +35,7 @@ module Aweplug
             builder.response :gzip
             builder.request :authorization, 'bearer', ENV['vimeo_access_token']
             builder.use FaradayMiddleware::FollowRedirects
-            builder.use FaradayMiddleware::Caching, @site.cache, {}
+            builder.use FaradayMiddleware::Caching, cache, {}
             builder.adapter adapter || :net_http
           end
         end


### PR DESCRIPTION
I've updated all the places in aweplug that do REST calls to use a
cache per type (one for videos, one for quickstarts, etc.) instead of
the single site wide cache. There is now no default ttl in the cache
itself, you'll need to specify one when you create a new instance of
the cache.

Please go over the defaults I have put in place and see if they make
sense.
