### PR TITLE
Fixes DEVELOPER-984 (videos accepting multiple products)

### DIFF
--- a/lib/aweplug/helpers/searchisko.rb
+++ b/lib/aweplug/helpers/searchisko.rb
@@ -152,6 +152,25 @@ module Aweplug
         post "/content/#{content_type}/#{content_id}", params
       end
 
+      # Public: Posts bulk content to Searchisko. See 
+      # http://docs.jbossorg.apiary.io/#post-%2Fv2%2Frest%2Fcontent%2F%7Bsys_content_type%7D
+      # for more information.
+      #
+      # content_type - String of the Searchisko sys_content_type for the content 
+      #                being posted.
+      # params       - Hash containing the content to push. Ids of each value
+      #                must be the key in the hash.
+      #
+      # Examples
+      #
+      #   searchisko.push_bulk_content 'jbossdeveloper_bom', content_hash
+      #   # => Faraday Response
+      #
+      # Returns a Faraday Response from the POST.
+      def push_bulk_content content_type, content = {}
+        post "/content/#{content_type}", content
+      end
+
       # Public: Perform an HTTP POST to Searchisko.
       #
       # path   - String containing the rest of the path.

--- a/lib/aweplug/helpers/video/helpers.rb
+++ b/lib/aweplug/helpers/video/helpers.rb
@@ -1,5 +1,7 @@
 require 'aweplug/cache'
 require 'awestruct/util/exception_helper'
+require 'uri/https'
+# TODO: Require searchisko helper
 
 module Aweplug
   module Helpers
@@ -15,6 +17,7 @@ module Aweplug
           begin
             if !File.exists?("#{site.dir}/_partials/#{path}")
               path = Pathname.new(File.dirname(__FILE__)).join(default_snippet)
+              binding.pry if video.is_a? Hash
               page.video = video
               Tilt.new(path.to_s).render(Object.new, :page => page, :site => site)
             else
@@ -29,9 +32,15 @@ module Aweplug
         def add_video(video, product, push_to_searchisko)
           output_path = File.join 'video', video.provider, "#{video.id}.html"
           unless @site.pages.any? {|p| p.output_path == output_path}
+            binding.pry if video.is_a? Hash
             add_video_to_site video, output_path, @site
-            send_video_to_searchisko video, @site, product, push_to_searchisko, Aweplug::Cache.default(@site)
+            video.add_target_product product if product
+            # TODO: Take this out do it elsewhere
+            #send_video_to_searchisko video, @site, product, push_to_searchisko, Aweplug::Cache.default(@site)
           end
+          url = URI.parse video.url
+          url.scheme = 'https' if url.scheme == 'http'
+          @site.videos[url.to_s] = video
           video
         end
 

--- a/lib/aweplug/helpers/video/video_base.rb
+++ b/lib/aweplug/helpers/video/video_base.rb
@@ -84,6 +84,7 @@ module Aweplug
             :sys_last_activity_date => modified_date.iso8601,
             :duration => duration.to_i,
             :thumbnail => thumb_url,
+            :target_product => target_product.flatten.compact.uniq,
             :tags => tags
           }.reject{ |k,v| v.nil? }
         end

--- a/lib/aweplug/helpers/video/vimeo_video.rb
+++ b/lib/aweplug/helpers/video/vimeo_video.rb
@@ -11,7 +11,8 @@ module Aweplug
       class VimeoVideo < ::Aweplug::Helpers::Video::VideoBase
         include Aweplug::Helpers::SearchiskoSocial
 
-        attr_reader :duration, :id, :tags, :url, :title, :thumb_url, :cast, :modified_date, :published_date, :normalized_cast
+        attr_reader :duration, :id, :tags, :url, :title, :thumb_url, 
+                    :cast, :modified_date, :published_date, :normalized_cast, :target_product
 
         def initialize video, credits, site
           super video, site
@@ -24,6 +25,7 @@ module Aweplug
           @modified_date = DateTime.parse(@video['modified_time'])
           @published_date = DateTime.parse(@video['created_time'])
           @cast = []
+          @target_product = []
           credits.each do |c|
             name = c['name']
             if c.has_key? 'user'
@@ -48,6 +50,10 @@ module Aweplug
 
         def embed color, width, height
           %Q{<div widescreen vimeo><iframe src="//player.vimeo.com/video/#{id}?title=0&byline=0&portrait=0&badge=0&color=#{color}" width="#{width}" height="#{height}" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>}
+        end
+
+        def add_target_product product
+          @target_product << product
         end
 
       end

--- a/lib/aweplug/helpers/video/youtube_video.rb
+++ b/lib/aweplug/helpers/video/youtube_video.rb
@@ -20,9 +20,11 @@ module Aweplug
           @cast = contributor_exclude.include?(@video['channelTitle']) ? [] : [ { :name => @video['channelTitle'] } ]
           @normalized_cast = @cast.collect { |c| normalize('contributor_profile_by_jbossdeveloper_quickstart_author', c[:name], @searchisko) }
           @modified_date = @published_date = DateTime.parse(@video['publishedAt'])
+          @target_product = []
         end
 
-        attr_reader :url, :id, :duration, :thumb_url, :cast, :modified_date, :published_date, :normalized_cast
+        attr_reader :url, :id, :duration, :thumb_url, :cast, :modified_date, 
+                    :published_date, :normalized_cast, :target_product
 
         def provider
           'youtube'
@@ -36,6 +38,9 @@ module Aweplug
           %Q{<iframe id="ytplayer" type="text/html" width="#{width}" height="#{height}" src="//www.youtube.com/embed/#{id}?&origin=#{@site.base_url}&color=#{color}&modestbranding=1" frameborder="0"></iframe>}
         end
 
+        def add_target_product product
+          @target_product << product
+        end
       end
     end
   end


### PR DESCRIPTION
Videos can now take multiple target products.
Videos are also collected in a hash in the site, and sent to searchisko
in one go. I have no idea if this will help speed things up, but it
certainly can't hurt.
Searchisko helper has a new method to do bulk inserts.