### PR TITLE
Fix for error due to uninitialized constant

### DIFF
--- a/lib/aweplug/extensions/video.rb
+++ b/lib/aweplug/extensions/video.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'parallel'
 require 'aweplug/helpers/video'
 require 'aweplug/helpers/searchisko'


### PR DESCRIPTION
I get the following error when trying to render the jboss.org site:

----
    While processing file 
    An error occurred: uninitialized constant ActiveSupport::Autoload
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.9/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.9/lib/active_support/number_helper.rb:2:in `<module:ActiveSupport>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.9/lib/active_support/number_helper.rb:1:in `<top (required)>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.9/lib/active_support/core_ext/numeric/conversions.rb:2:in `require'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.9/lib/active_support/core_ext/numeric/conversions.rb:2:in `<top (required)>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.9/lib/active_support/core_ext/numeric.rb:3:in `require'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.9/lib/active_support/core_ext/numeric.rb:3:in `<top (required)>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.9/lib/active_support/core_ext.rb:2:in `require'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.9/lib/active_support/core_ext.rb:2:in `block in <top (required)>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.9/lib/active_support/core_ext.rb:1:in `each'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/activesupport-4.1.9/lib/active_support/core_ext.rb:1:in `<top (required)>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/ruby-duration-3.1.0/lib/duration.rb:3:in `require'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/ruby-duration-3.1.0/lib/duration.rb:3:in `<top (required)>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bundler/gems/aweplug-ecd6d369ff1c/lib/aweplug/helpers/video/vimeo_video.rb:4:in `require'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bundler/gems/aweplug-ecd6d369ff1c/lib/aweplug/helpers/video/vimeo_video.rb:4:in `<top (required)>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bundler/gems/aweplug-ecd6d369ff1c/lib/aweplug/helpers/video/vimeo.rb:3:in `require'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bundler/gems/aweplug-ecd6d369ff1c/lib/aweplug/helpers/video/vimeo.rb:3:in `<top (required)>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bundler/gems/aweplug-ecd6d369ff1c/lib/aweplug/helpers/video.rb:1:in `require'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bundler/gems/aweplug-ecd6d369ff1c/lib/aweplug/helpers/video.rb:1:in `<top (required)>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bundler/gems/aweplug-ecd6d369ff1c/lib/aweplug/extensions/video.rb:2:in `require'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bundler/gems/aweplug-ecd6d369ff1c/lib/aweplug/extensions/video.rb:2:in `<top (required)>'
    /home/vreynolds/git-repos/www.jboss.org/_ext/pipeline.rb:7:in `require'
    /home/vreynolds/git-repos/www.jboss.org/_ext/pipeline.rb:7:in `load_pipeline'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/awestruct-0.5.6.beta8/lib/awestruct/engine.rb:243:in `eval'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/awestruct-0.5.6.beta8/lib/awestruct/engine.rb:243:in `load_pipeline'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/awestruct-0.5.6.beta8/lib/awestruct/engine.rb:67:in `run'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/awestruct-0.5.6.beta8/lib/awestruct/cli/generate.rb:21:in `run'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/awestruct-0.5.6.beta8/lib/awestruct/cli/invoker.rb:125:in `invoke_generate'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/awestruct-0.5.6.beta8/lib/awestruct/cli/invoker.rb:49:in `invoke!'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/gems/awestruct-0.5.6.beta8/bin/awestruct:9:in `<top (required)>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bin/awestruct:23:in `load'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bin/awestruct:23:in `<main>'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bin/ruby_executable_hooks:15:in `eval'
    /home/vreynolds/.rvm/gems/ruby-2.1.2/bin/ruby_executable_hooks:15:in `<main>'
-----

This PR incorporates the fix suggested at https://github.com/rails/rails/issues/14664.

With the locally built gem, I get past the reported error.

FYI, my env is:

Fedora 21, Ruby 2.1.2 (managed by RVM)