### PR TITLE
DEVELOPER-1232 Fixed the headers to authenticate with Github API to prevent issues with the ratelimit.

### DIFF
--- a/lib/aweplug/extensions/kramdown_demo.rb
+++ b/lib/aweplug/extensions/kramdown_demo.rb
@@ -185,6 +185,7 @@ module Aweplug
             end
             builder.request :url_encoded
             builder.request :retry
+            builder.headers['Authorization'] = 'token ' + ENV['github_token']
             builder.use FaradayMiddleware::Caching, @cache, {}
             builder.use FaradayMiddleware::FollowRedirects, limit: 3
             builder.adapter Faraday.default_adapter 


### PR DESCRIPTION
The faraday token method is crap...this works locally.  Time to make sure that it works on staging.