### PR TITLE
DEVELOPER-1241 An error occurred: can't add a new key into hash during iteration

### DIFF
--- a/lib/aweplug/extensions/video.rb
+++ b/lib/aweplug/extensions/video.rb
@@ -34,6 +34,7 @@ module Aweplug
         Parallel.each(eval(@variable), :in_threads => (site.build_threads || 0)) do |u|
           (add_video u, site, push_to_searchisko: @push_to_searchisko) unless u.nil?
         end
+        site.videos.reject! { |k,v| v.nil? }
         unless site.profile =~ /development/
           searchisko = Aweplug::Helpers::Searchisko.default site, 21600 # 6 hour default 
 

--- a/lib/aweplug/helpers/video.rb
+++ b/lib/aweplug/helpers/video.rb
@@ -58,7 +58,6 @@ module Aweplug
           
           videos[uri_key].add_target_product(product) if (videos[uri_key] && product)
         end
-        videos.reject! { |k,v| v.nil? }
         site.videos.merge! videos
         videos[uri_key]
       end


### PR DESCRIPTION
This does not significantly affect build times.

The multithreading for adding the videos doesn't seem to be thread safe on the hash map.  Without a mutex, the only solution is to remove multithreading on this for now.