### PR TITLE
Fixes DEVELOPER-1814 (drupal cdn)

### DIFF
--- a/aweplug.gemspec
+++ b/aweplug.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   #gem.add_dependency 'rugged', '~> 0.19'
   gem.add_dependency 'parallel', '> 1.0.0'
   gem.add_dependency 'xml-simple', '~> 1.1'
-  gem.add_dependency 'google-api-client', '~> 0.7'
+  gem.add_dependency 'google-api-client', '~> 0.7', '< 0.9'
   gem.add_dependency 'ruby-duration', '~> 3.2'
   gem.add_dependency 'kramdown', '~> 1.0.2'
   gem.add_dependency 'typhoeus', '~> 0.7'

--- a/lib/aweplug/helpers/cdn.rb
+++ b/lib/aweplug/helpers/cdn.rb
@@ -62,10 +62,12 @@ module Aweplug
         unless build_no.nil?
           name = name + "-" + build_no
         end
-        unless ENV_PREFIX.nil?
-          Pathname.new(ENV_PREFIX).join(@ctx_path).join(name + ext).to_s
-        else
+        if ENV_PREFIX.nil?
           Pathname.new(@ctx_path).join(name + ext)
+        elsif ENV_PREFIX =~ /sites\/default\/files/ # we're running for drupal
+          Pathname.new(ENV_PREFIX).join(name + ext).to_s
+        else
+          Pathname.new(ENV_PREFIX).join(@ctx_path).join(name + ext).to_s
         end
       end
    


### PR DESCRIPTION
We can still use this for drupal as a the cdn, just had to make a small change in the path generation. Also google-api-client has revved to 0.9 but there are some migrations that need to happen, which we're not doing right now.