### PR TITLE
Changes to the sys_url_view value

### DIFF
--- a/lib/aweplug/books/google_books.rb
+++ b/lib/aweplug/books/google_books.rb
@@ -121,7 +121,7 @@ module Aweplug
           {
             :sys_title => book['volumeInfo']['title'],
             :sys_description => description,
-            :sys_url_view => book['volumeInfo']['canonicalVolumeLink'],
+            :sys_url_view => book['volumeInfo']['infoLink'],
             :authors => book['volumeInfo']['authors'],
             :thumbnail => thumbnail.to_s,
             :isbn => isbn,


### PR DESCRIPTION
@paulrobinson - Can you merge this when you get the chance? This replaces the canonicalVolumeLink (since they are pretty much always null) with the infolink. The infolink directs to the page with the books information and purchase information.